### PR TITLE
Fix param replaceable even format in filters

### DIFF
--- a/src/hooks/nostrQueries/zaps/useZapsQuery.js
+++ b/src/hooks/nostrQueries/zaps/useZapsQuery.js
@@ -16,7 +16,7 @@ export function useZapsQuery({ event, type }) {
 
             const filters = [
                 { kinds: [9735], "#e": [event.id] },
-                { kinds: [9735], "#a": [`${event.kind}:${event.id}:${event.d}`] }
+                { kinds: [9735], "#a": [`${event.kind}:${event.pubkey}:${event.d}`] }
             ];
 
             const events = await ndk.fetchEvents(filters, { closeOnEose: true });

--- a/src/hooks/nostrQueries/zaps/useZapsSubscription.js
+++ b/src/hooks/nostrQueries/zaps/useZapsSubscription.js
@@ -26,7 +26,7 @@ export function useZapsSubscription({ event }) {
       try {
         const filters = [
           { kinds: [9735], "#e": [event.id] },
-          { kinds: [9735], "#a": [`${event.kind}:${event.pubkey}:${event.id}`] }
+          { kinds: [9735], "#a": [`${event.kind}:${event.pubkey}:${event.d}`] }
         ];
 
         subscription = ndk.subscribe(filters, {

--- a/src/utils/lightning.js
+++ b/src/utils/lightning.js
@@ -10,7 +10,7 @@ export const getTotalFromZaps = (zaps, event) => {
     let uniqueZaps = new Set();
     zaps.forEach((zap) => {
       // If the zap matches the event or the parameterized event, then add the zap to the total
-      if ((zap.tags.find(tag => tag[0] === "e" && tag[1] === event.id) || zap.tags.find(tag => tag[0] === "a" && tag[1] === `${event.kind}:${event.id}:${event.d}`)) &&!uniqueZaps.has(zap.id)) {
+      if ((zap.tags.find(tag => tag[0] === "e" && tag[1] === event.id) || zap.tags.find(tag => tag[0] === "a" && tag[1] === `${event.kind}:${event.pubkey}:${event.d}`)) &&!uniqueZaps.has(zap.id)) {
         uniqueZaps.add(zap.id);
         const bolt11Tag = zap.tags.find(tag => tag[0] === "bolt11");
         const invoice = bolt11Tag ? bolt11Tag[1] : null;


### PR DESCRIPTION
Fix param replaceable even format in filters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refined zap event filtering to improve the accuracy of displayed zap events.
  - Adjusted subscription criteria for zap events, ensuring more consistent and expected updates for end users.
  - Enhanced the logic for processing zaps based on associated tags, potentially improving the uniqueness of zap totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->