### PR TITLE
Handle fallback for component already initialized

### DIFF
--- a/src/components/bitcoinConnect/BitcoinConnect.js
+++ b/src/components/bitcoinConnect/BitcoinConnect.js
@@ -12,13 +12,24 @@ let initialized = false;
 
 export async function initializeBitcoinConnect() {
   if (!initialized) {
-    const { init } = await import('@getalby/bitcoin-connect-react');
-    init({
-      appName: "PlebDevs",
-      filters: ["nwc"],
-      showBalance: false
-    });
-    initialized = true;
+    try {
+      const { init } = await import('@getalby/bitcoin-connect-react');
+      // Check if custom elements are already registered
+      if (!customElements.get('bc-balance')) {
+        init({
+          appName: "PlebDevs",
+          filters: ["nwc"],
+          showBalance: false
+        });
+        initialized = true;
+      }
+    } catch (error) {
+      // If the error is about custom element already being defined, we can ignore it
+      // as it means the component is already initialized
+      if (!error.message?.includes('has already been defined as a custom element')) {
+        console.error('Error initializing Bitcoin Connect:', error);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fix for this err:

```
Uncaught (in promise) DOMException: CustomElementRegistry.define: 'bc-balance' has already been defined as a custom element
    Ae webpack-internal:///./node_modules/@getalby/bitcoin-connect/dist/index.modern.js:1605
    C webpack-internal:///./node_modules/@getalby/bitcoin-connect/dist/index.modern.js:386
    <anonymous> webpack-internal:///./node_modules/@getalby/bitcoin-connect/dist/index.modern.js:4308
    NextJS 4
    <anonymous> webpack-internal:///./node_modules/@getalby/bitcoin-connect-react/dist/index.modern.js:23
    NextJS 4
    promise callback*initializeBitcoinConnect webpack-internal:///./src/components/bitcoinConnect/BitcoinConnect.js:27
    SubscriptionPaymentButtons webpack-internal:///./src/components/bitcoinConnect/SubscriptionPaymentButton.js:60
    React 7
    workLoop webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:227
    flushWork webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:205
    performWorkUntilDeadline webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:442
    EventHandlerNonNull* webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:478
    <anonymous> webpack-internal:///./node_modules/scheduler/cjs/scheduler.development.js:528
    NextJS 4
    <anonymous> webpack-internal:///./node_modules/scheduler/index.js:4
    NextJS 4
    React 2
    NextJS 4
    <anonymous> React
    NextJS 4
    <anonymous> React
    NextJS 4
    <anonymous> webpack-internal:///./node_modules/next/dist/client/index.js:42
    NextJS 4
    <anonymous> webpack-internal:///./node_modules/next/dist/client/next-dev.js:9
    NextJS 7
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**  
  - Improved the stability of the Bitcoin connection process. The initialization now gracefully handles duplicate setup attempts, ensuring a more seamless experience when using Bitcoin-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->