### PR TITLE
remove empty space when sidebar closed, fix transition animation

### DIFF
--- a/src/components/content/courses/layout/CourseSidebar.js
+++ b/src/components/content/courses/layout/CourseSidebar.js
@@ -125,12 +125,10 @@ const CourseSidebar = ({
       )}
       
       {/* Desktop sidebar */}
-      {!isMobileView && (
+      {!isMobileView && sidebarVisible && (
         <div className="relative flex flex-row-reverse z-[999]">
           <div 
-            className={`transition-all duration-500 ease-in-out flex ${
-              sidebarVisible ? 'w-80 opacity-100' : 'w-0 opacity-0 overflow-hidden'
-            }`}
+            className={`transition-all duration-500 ease-in-out flex w-80 opacity-100`}
           >
             <div className="ml-2 w-80 h-[calc(100vh-400px)] sticky overflow-hidden rounded-lg border border-gray-800 shadow-md bg-gray-800"
                  style={{ top: `${navbarHeight + 70}px` }}> {/* Adjusted to match new header spacing */}

--- a/src/pages/course/[slug]/index.js
+++ b/src/pages/course/[slug]/index.js
@@ -278,20 +278,21 @@ const Course = () => {
           </div>
 
           {/* Course Sidebar - positioned absolutely on desktop when visible */}
-          {!isMobileView ? (
-            <div 
-              className={`transition-all duration-500 ease-in-out ${
-                sidebarVisible ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-full'
-              }`}
+          {!isMobileView && (
+            <div
+              className={`transition-all duration-500 ease-in-out absolute top-0 right-0 w-[320px] h-full z-[999] overflow-visible
+                ${sidebarVisible ? 'opacity-100 translate-x-0 pointer-events-auto' : 'opacity-0 translate-x-full pointer-events-none'}
+              `}
               style={{
-                position: 'absolute',
-                top: '0',
-                right: '0',
-                width: '320px',
-                height: '100%',
-                zIndex: 999,
-                overflow: 'visible',
-                pointerEvents: sidebarVisible ? 'auto' : 'none'
+                // You can keep these if you want, but they're now in the className above
+                // position: 'absolute',
+                // top: '0',
+                // right: '0',
+                // width: '320px',
+                // height: '100%',
+                // zIndex: 999,
+                // overflow: 'visible',
+                // pointerEvents: sidebarVisible ? 'auto' : 'none'
               }}
             >
               <CourseSidebar
@@ -300,26 +301,6 @@ const Course = () => {
                 onLessonSelect={handleLessonSelect}
                 completedLessons={completedLessons}
                 isMobileView={isMobileView}
-                sidebarVisible={sidebarVisible}
-                setSidebarVisible={setSidebarVisible}
-                hideToggleButton={true}
-              />
-            </div>
-          ) : (
-            <div className={`flex-shrink-0 transition-all duration-300 z-[999] ${
-              (isMobileView && activeTab === 'lessons') ? 'ml-0 w-auto opacity-100' : 
-              'w-0 ml-0 opacity-0 overflow-hidden'
-            }`}>
-              <CourseSidebar
-                lessons={uniqueLessons}
-                activeIndex={activeIndex}
-                onLessonSelect={handleLessonSelect}
-                completedLessons={completedLessons}
-                isMobileView={isMobileView}
-                onClose={() => {
-                  setSidebarVisible(false);
-                  toggleTab(getActiveTabIndex());
-                }}
                 sidebarVisible={sidebarVisible}
                 setSidebarVisible={setSidebarVisible}
                 hideToggleButton={true}

--- a/src/pages/course/[slug]/index.js
+++ b/src/pages/course/[slug]/index.js
@@ -283,17 +283,6 @@ const Course = () => {
               className={`transition-all duration-500 ease-in-out absolute top-0 right-0 w-[320px] h-full z-[999] overflow-visible
                 ${sidebarVisible ? 'opacity-100 translate-x-0 pointer-events-auto' : 'opacity-0 translate-x-full pointer-events-none'}
               `}
-              style={{
-                // You can keep these if you want, but they're now in the className above
-                // position: 'absolute',
-                // top: '0',
-                // right: '0',
-                // width: '320px',
-                // height: '100%',
-                // zIndex: 999,
-                // overflow: 'visible',
-                // pointerEvents: sidebarVisible ? 'auto' : 'none'
-              }}
             >
               <CourseSidebar
                 lessons={uniqueLessons}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the sidebar to display only on desktop views, removing the mobile sidebar.
  - Enhanced sidebar visibility control through conditional rendering instead of CSS transitions.
  - Streamlined sidebar styling and pointer event management for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->